### PR TITLE
pin gdal to 2.2*

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -34,6 +34,7 @@ pinned = {
           'fontconfig': 'fontconfig 2.12.*',
           'freetype': 'freetype 2.7|2.7.*',
           'geos': 'geos 3.5.1',
+          'gdal': 'gdal 2.2.*',
           'giflib': 'giflib 5.1.*',
           'glib': 'glib 2.51.*',
           'gmp': 'gmp >=5.0.1,<7',


### PR DESCRIPTION
Using `gdal 1.*` is now a special case and we should pin software to `gdal 2.2*` to ensure stability. `gdal` has tons of dependencies that may cause unstable envs when not properly pinned.

@gillins are you OK with this pin?